### PR TITLE
Responsive css suggestions

### DIFF
--- a/client/src/components/StackCalculationDisplay.tsx
+++ b/client/src/components/StackCalculationDisplay.tsx
@@ -219,35 +219,34 @@ const StackCalculationDisplay: React.FC<{
           );
         })}
       </div>
-      <div className="fetch-results-title-container">
-        <div className="title-results-container overall">
-          Top 5 Overall Selected Items
+      <div className="new-results-container">
+        <div className="sub-container">
+          <div className="title">Top 5 Overall Selected Items</div>
+          {isLoading ? (
+            <LoadingDisplay />
+          ) : (
+            <div className="top-results-container">
+              <TopSelectedItems dbItems={topItems} />
+            </div>
+          )}
         </div>
-        <div className="title-results-container">
-          Top 5 Selected Items for
-          <img
-            className="results-survivor-image"
-            src={userSelection.userSurvivor.imageLink}
-            alt={`image of ${userSelection.userSurvivor.name}`}
-            onMouseOver={playHoverSound}
-          />
+        <div className="sub-container">
+          <div className="title">Top 5 Selected Items for
+            <img
+              className="results-survivor-image"
+              src={userSelection.userSurvivor.imageLink}
+              alt={`image of ${userSelection.userSurvivor.name}`}
+              onMouseOver={playHoverSound}
+            />
+          </div>
+          {isLoading ? (
+            <LoadingDisplay />
+          ) : (
+            <div className="top-results-container">
+              <TopSelectedItems dbItems={topSurvivorItems} />
+            </div>
+          )}
         </div>
-      </div>
-      <div className="fetch-results-container">
-        {isLoading ? (
-          <LoadingDisplay />
-        ) : (
-          <div className="top-results-container overall">
-            <TopSelectedItems dbItems={topItems} />
-          </div>
-        )}
-        {isLoading ? (
-          <LoadingDisplay />
-        ) : (
-          <div className="top-results-container survivor">
-            <TopSelectedItems dbItems={topSurvivorItems} />
-          </div>
-        )}
       </div>
       <div className="refresh">
         <button

--- a/client/src/styles/itemStackDisplay.css
+++ b/client/src/styles/itemStackDisplay.css
@@ -67,47 +67,12 @@
   margin-left: -20px;
 }
 
-.fetch-results-title-container {
-  display: flex;
-}
-
-.fetch-results-container {
-  display: flex;
-  margin-left: 10px;
-  margin-right: 10px;
-  z-index: -1;
-}
-
-.title-results-container {
-  flex: 1;
-  text-align: center;
-  margin-top: 10px;
-  font-size: 1.5rem;
-  border: 2px solid #5A5865;
-  background-color: #2F2C37;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 60px;
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
 .results-survivor-image {
   border: 1px solid #CAC686;
   border-radius: 1px;
   padding: 2px;
   margin: 8px;
   width: 50px;
-}
-
-.overall {
-  margin-right: 10px;
-}
-
-.survivor {
-  margin-left: 10px;
-  position: relative;
 }
 
 .top-results-container {
@@ -117,7 +82,7 @@
   justify-content: space-evenly;
   border: 1px solid #CAC686;
   padding: 20px;
-  margin-top: 10px;
+  margin: 10px 10px 10px 0;
 }
 
 .ranked-item-rarity {
@@ -152,4 +117,28 @@ li {
   align-items: center;
   margin-bottom: 10px;
   margin-top: -10px;
+}
+
+.new-results-container {
+  display: flex;
+  flex-wrap: wrap;
+
+  .sub-container {
+    flex: 1 1 0;
+
+    .title {
+      flex: 1;
+      text-align: center;
+      margin-top: 10px;
+      font-size: 1.5rem;
+      border: 2px solid #5A5865;
+      background-color: #2F2C37;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 60px;
+      margin-left: 10px;
+      margin-right: 10px;
+    }
+  }
 }

--- a/client/src/styles/items.css
+++ b/client/src/styles/items.css
@@ -1,5 +1,6 @@
 .item-image {
   width: 70%;
+  max-width: 76px;
   padding: 2px;
   margin: 3px;
   z-index: 1;
@@ -32,34 +33,32 @@ span {
   display: flex;
   align-items: center;
   justify-content: space-evenly;
-  max-width: 70%;
   margin: 0 auto;
 }
 
 .multishop {
   /* width: 10%; */
+  flex: 0 0 auto;
   height: 50vh;
   display: flex;
   align-items: center;
   justify-content: center;
   position: relative;
-  margin: 0 90px;
   background-color: #242424;
-  min-width: 105px;
-  max-width: 105px;
   border-left: 3px solid blue;
   border-right: 3px solid blue;
   z-index: 1;
-  flex: 1
+}
+
+.multishop > * {
+  flex: 0 0 auto;
 }
 
 .multishop-top {
-  width: 175px;
   height: 15%;
   position: absolute;
   top: 0%;
   border: 1px solid blue;
-  /* max-width: 175px; */
   background-color: blue;
   display: flex;
   align-items: center;
@@ -67,14 +66,12 @@ span {
 }
 
 .multishop-cap {
-  width: 175px;
   height:15%;
   position: absolute;
   top: -6%;
   border: 1px solid blue;
   border-radius: 40%;
   overflow: hidden;
-  /* max-width: 175px; */
   background-color: blue;
   z-index: 3;
 }
@@ -84,7 +81,6 @@ span {
   border-bottom: 30px solid blue;
 	border-left: 25px solid transparent;
 	border-right: 25px solid transparent;
-	width: 90px;
   top: -8%;
   z-index: 2;
 }
@@ -99,13 +95,11 @@ span {
 }
 
 .multishop-bottom {
-  width: 175px;
   height: 10%;
   position: absolute;
   bottom: -1%;
   border: 1px solid blue;
   border-radius: 0 0 30px 30px;
-  /* max-width: 175px; */
   background-color: blue;
   z-index: 2;
 }
@@ -168,41 +162,55 @@ span {
   margin-right: 5px;
 }
 
-/* @media (max-width: 1339px) {
-
-  .multishop-container {
-    max-width: none;
-  }
-  .multishop {
-    margin: 0 50px;
+/* Extra small devices (phones, 600px and down) */
+@media only screen and (max-width: 600px) {
+  .multishop-top, .multishop-cap, .multishop-bottom {
+    width: 130%;
   }
 
-  .multishop-top, .multishop-bottom, .multishop-cap {
-    min-width: 175px;
-  }
   .multishop-cap-tip {
-    min-width: 9.5vw;
+    width: 60%;
   }
-} */
+}
 
-/* @media (min-width: 1441px) {
-  .multishop-top, .multishop-bottom, .multishop-cap {
-    max-width: 205px;
+/* Small devices (portrait tablets and large phones, 600px and up) */
+@media only screen and (min-width: 600px) and (max-width: 767px) {
+  .multishop-top, .multishop-cap, .multishop-bottom {
+    width: 160%;
   }
+
+  .multishop-cap-tip {
+    width: 80%;
+  }
+}
+
+/* Medium devices (landscape tablets, 768px and up) */
+@media only screen and (min-width: 768px) and (max-width: 991px) {
   .multishop {
-    max-width: 120px;
+    margin: 0 90px;
   }
-} */
 
-@media (max-width: 768px) {
-  /* .multishop-top, .multishop-bottom, .multishop-cap {
-    min-width: 175px;
-  } */
+  .multishop-top, .multishop-cap, .multishop-bottom {
+    width: 175px;
+  }
+
+  .multishop-cap-tip {
+    width: 90px;;
+  }
+}
+
+/* Large devices (laptops/desktops, 992px and up) */
+@media only screen and (min-width: 992px) {
   .multishop {
-    margin: 0 50px;
+    margin: 0 90px;
+    width: 105px;
   }
-  /* .multishop-cap-tip {
-    min-width: 12.5vw;
-  } */
 
+  .multishop-top, .multishop-cap, .multishop-bottom {
+    width: 175px;
+  }
+
+  .multishop-cap-tip {
+    width: 90px;;
+  }
 }


### PR DESCRIPTION
I made some quick changes that could vastly improve the user experience on two screens. This is just a starting point.

1. Item selection screen:
- moved all width-related stylings into media queries
- width of `multishop`'s on mobile and tablet are dependent on screen width

Mobile:
![image](https://github.com/JeffreyChuCPA/Risk-of-Rain-2-Multishop-Simulator/assets/4600682/bb5c2dd1-3ec0-4cd6-af1d-a7cbebad22d5)

Tablet:
![image](https://github.com/JeffreyChuCPA/Risk-of-Rain-2-Multishop-Simulator/assets/4600682/f98d864b-06e6-4c20-bbd1-2a7394783cc6)

Further room for improvement:
- the multishop cap and tip might need some fixing
- hover message on mobile should be moved into a static text container that only appears on mobile and tablet breakpoints

2. Results screen
- restructured the flex containers so that the title and selected items are part of the same container
- on mobile, show one "Top 5 XXX" item at a time instead of having them side-by-side

Original:
![image](https://github.com/JeffreyChuCPA/Risk-of-Rain-2-Multishop-Simulator/assets/4600682/6c7c39b3-3fd1-473d-8eda-088630262340)

Now:
![image](https://github.com/JeffreyChuCPA/Risk-of-Rain-2-Multishop-Simulator/assets/4600682/f5566432-0176-49ac-a2d5-bae72311d294)
